### PR TITLE
Update libzookeeper versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ php:
     - 5.3
 
 env:
-    - LIBZOOKEEPER_VERSION=3.5.0-alpha
-    - LIBZOOKEEPER_VERSION=3.4.6
+    - LIBZOOKEEPER_VERSION=3.5.2-alpha
+    - LIBZOOKEEPER_VERSION=3.4.8
 
 install:
     - sudo apt-get install -y lcov


### PR DESCRIPTION
* From https://github.com/andreiz/php-zookeeper/pull/74
* Current version in Ubuntu LTS is 3.4.8