### PR TITLE
Fix: Segfault when creating keys

### DIFF
--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -856,8 +856,6 @@ static void php_zk_destroy(php_zk_t *i_obj TSRMLS_DC)
 {
 	php_zk_close(i_obj TSRMLS_CC);
 	zend_hash_destroy(&i_obj->callbacks);
-
-	efree(i_obj);
 }
 
 static void php_zk_free_storage(zend_object *obj TSRMLS_DC)


### PR DESCRIPTION
This line had ```ifndef ZEND_ENGINE_3``` around it but was not removed with the ifndef.

https://github.com/php-zookeeper/php-zookeeper/commit/5acfe9a9f9db408e92f9225d9b869f82a934648c#diff-4dcc63437fb368928b930d66b19f7b35L854

Reproducible test script to prove the segfault:

```php
function create($key)
{
    $store = new \Zookeeper('127.0.0.1:2181');
    $store->create(
        $key,
        '',
        [[ 'perms' => \Zookeeper::PERM_ALL, 'scheme' => 'world', 'id' => 'anyone' ]],
        \Zookeeper::EPHEMERAL
    );
}

create('/' . uniqid());
create('/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' . uniqid());
```

The error was discovered by Symfony when we upgraded ext/zookeeper to 0.6.2 in our Travis builds.

https://github.com/symfony/symfony/pull/29624