### PR TITLE
Fix build with PHP 7.4

### DIFF
--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -1064,7 +1064,7 @@ static void php_parse_acl_list(zval *z_acl, struct ACL_vector *aclv)
 {
 	int size = 0;
 	int i = 0;
-	ulong index = 0;
+	zend_ulong index = 0;
 	zend_string *key;
 	zval *entry = NULL;
 	zval *perms = NULL;

--- a/php_zookeeper_callback.h
+++ b/php_zookeeper_callback.h
@@ -24,7 +24,7 @@ typedef struct _php_cb_data_t {
     zend_fcall_info fci;
     zend_fcall_info_cache fcc;
     zend_bool oneshot;
-    ulong h;
+    zend_ulong h;
     HashTable *ht;
 #if ZTS
     void ***ctx;


### PR DESCRIPTION
Build error on FreeBSD with PHP 7.4 RC6:
```
--- php_zookeeper_session.lo ---
/bin/sh /wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/libtool --mode=compile cc -I/usr/local/include/php -I. -I/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1 -DPHP_ATOM_INC -I/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/include -I/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/main -I/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1 -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib -I/usr/local/include/zookeeper  -DHAVE_CONFIG_H  -O2 -pipe -fstack-protector -fno-strict-aliasing   -c /wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper_session.c -o php_zookeeper_session.loict-aliasing -c /wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper_session.c  -fPIC -DPIC -o .libs/php_zookeeper_session.o
./php_zookeeper_callback.h:27:5: error: unknown type name 'ulong'
    ulong h;
    ^
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1071:7: error: expected ';' after expression
        ulong index = 0;
             ^
             ;
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1071:2: error: use of undeclared identifier 'ulong'
        ulong index = 0;
        ^
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1071:14: error: non-object type 'char *(const char *, int)' is not assignable
        ulong index = 0;
              ~~~~~ ^
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1084:2: error: non-object type 'char *(const char *, int)' is not assignable
        ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(z_acl), index, key, entry) {
        ^                                            ~~~~~
/usr/local/include/php/Zend/zend_hash.h:1005:5: note: expanded from macro 'ZEND_HASH_FOREACH_KEY_VAL'
        _h = _p->h; \
        ~~ ^
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1544:44: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
        snprintf(buf, sizeof(buf), "%ld.%ld.%ld", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
                                    ~~~           ^~~~~~~~~~~~~~~~~
                                    %d
/usr/local/include/zookeeper/zookeeper_version.h:25:27: note: expanded from macro 'ZOO_MAJOR_VERSION'
 #define ZOO_MAJOR_VERSION 3
                           ^
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1544:63: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
        snprintf(buf, sizeof(buf), "%ld.%ld.%ld", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
                                        ~~~                          ^~~~~~~~~~~~~~~~~
                                        %d
/usr/local/include/zookeeper/zookeeper_version.h:26:27: note: expanded from macro 'ZOO_MINOR_VERSION'
 #define ZOO_MINOR_VERSION 5
                           ^
/wrkdirs/usr/ports/devel/pecl-zookeeper/work-php74/zookeeper-0.7.1/php_zookeeper.c:1544:82: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
        snprintf(buf, sizeof(buf), "%ld.%ld.%ld", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
                                            ~~~                                         ^~~~~~~~~~~~~~~~~
                                            %d
/usr/local/include/zookeeper/zookeeper_version.h:27:27: note: expanded from macro 'ZOO_PATCH_VERSION'
 #define ZOO_PATCH_VERSION 5
                           ^
3 warnings and 5 errors generated.
*** [php_zookeeper.lo] Error code 1
```