### PR TITLE
Fix build libzookeeper 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
   apt:
     packages:
       - lcov
+      - libcppunit-dev
 
 sudo: false
 

--- a/config.m4
+++ b/config.m4
@@ -107,11 +107,15 @@ if test "$PHP_ZOOKEEPER" != "no"; then
     ])
 
     AC_MSG_CHECKING([whether ZooKeeper Config is enabled])
+    ZOO_VERSION=$(cat ${PHP_LIBZOOKEEPER_INCDIR}/zookeeper_version.h |grep ZOO_VERSION|awk '{print $3}')
     ZOO_MINOR_VERSION=$(cat ${PHP_LIBZOOKEEPER_INCDIR}/zookeeper_version.h |grep ZOO_MINOR_VERSION|awk '{print $3}')
     PHP_ZOOKEEPER_CONFIG_FILES=""
-    if test ${ZOO_MINOR_VERSION} -eq 5; then
+    if test $ZOO_VERSION; then
       PHP_ZOOKEEPER_CONFIG_FILES="php_zookeeper_config_class.c"
-      AC_MSG_RESULT([enabled])
+      AC_MSG_RESULT([enabled with ZOO_VERSION])
+    elif test ${ZOO_MINOR_VERSION} -eq 5; then
+      PHP_ZOOKEEPER_CONFIG_FILES="php_zookeeper_config_class.c"
+      AC_MSG_RESULT([enabled with ZOO_MINOR_VERSION])
     else
       AC_MSG_RESULT([disabled])
     fi

--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -772,7 +772,7 @@ static PHP_METHOD(Zookeeper, dispatch)
 }
 /* }}} */
 
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 /* {{{ Zookeeper::getConfig( .. )
    */
 static PHP_METHOD(Zookeeper, getConfig)
@@ -1250,7 +1250,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_dispatch, 0)
 ZEND_END_ARG_INFO()
 
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 ZEND_BEGIN_ARG_INFO(arginfo_getConfig, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -1290,7 +1290,7 @@ static zend_function_entry zookeeper_class_methods[] = {
 
 	ZK_ME_STATIC(dispatch,    arginfo_dispatch)
 
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 	ZK_ME(getConfig,          arginfo_getConfig)
 #endif
 
@@ -1381,7 +1381,7 @@ static void php_zk_register_constants(INIT_FUNC_ARGS)
 	ZK_CLASS_CONST_LONG2(OPERATIONTIMEOUT);
 	ZK_CLASS_CONST_LONG2(BADARGUMENTS);
 	ZK_CLASS_CONST_LONG2(INVALIDSTATE);
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 	ZK_CLASS_CONST_LONG2(NEWCONFIGNOQUORUM);
 	ZK_CLASS_CONST_LONG2(RECONFIGINPROGRESS);
 #endif
@@ -1463,7 +1463,7 @@ PHP_MINIT_FUNCTION(zookeeper)
 
 	php_zk_register_exceptions(TSRMLS_C);
 
-#if defined(ZOO_VERSION) || defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 	php_zk_config_register(TSRMLS_C);
 #endif
 

--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -772,7 +772,7 @@ static PHP_METHOD(Zookeeper, dispatch)
 }
 /* }}} */
 
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 /* {{{ Zookeeper::getConfig( .. )
    */
 static PHP_METHOD(Zookeeper, getConfig)
@@ -1250,7 +1250,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_dispatch, 0)
 ZEND_END_ARG_INFO()
 
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 ZEND_BEGIN_ARG_INFO(arginfo_getConfig, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -1290,7 +1290,7 @@ static zend_function_entry zookeeper_class_methods[] = {
 
 	ZK_ME_STATIC(dispatch,    arginfo_dispatch)
 
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 	ZK_ME(getConfig,          arginfo_getConfig)
 #endif
 
@@ -1381,7 +1381,7 @@ static void php_zk_register_constants(INIT_FUNC_ARGS)
 	ZK_CLASS_CONST_LONG2(OPERATIONTIMEOUT);
 	ZK_CLASS_CONST_LONG2(BADARGUMENTS);
 	ZK_CLASS_CONST_LONG2(INVALIDSTATE);
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 	ZK_CLASS_CONST_LONG2(NEWCONFIGNOQUORUM);
 	ZK_CLASS_CONST_LONG2(RECONFIGINPROGRESS);
 #endif
@@ -1463,7 +1463,7 @@ PHP_MINIT_FUNCTION(zookeeper)
 
 	php_zk_register_exceptions(TSRMLS_C);
 
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
 	php_zk_config_register(TSRMLS_C);
 #endif
 
@@ -1537,7 +1537,11 @@ PHP_MINFO_FUNCTION(zookeeper)
 	php_info_print_table_header(2, "zookeeper support", "enabled");
 	php_info_print_table_row(2, "version", PHP_ZOOKEEPER_VERSION);
 
+#if defined(ZOO_VERSION)
+	snprintf(buf, sizeof(buf), "%s", ZOO_VERSION);
+#else
 	snprintf(buf, sizeof(buf), "%ld.%ld.%ld", ZOO_MAJOR_VERSION, ZOO_MINOR_VERSION, ZOO_PATCH_VERSION);
+#endif
 	php_info_print_table_row(2, "libzookeeper version", buf);
 
 	php_info_print_table_end();

--- a/php_zookeeper_log.c
+++ b/php_zookeeper_log.c
@@ -19,7 +19,7 @@
 #include <zookeeper_log.h> /* Symbol LOG_INFO defined in this file conflicts with the symbol defined in syslog.h */
 #include "php_zookeeper_log.h"
 
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 #define PHP_ZK_LOG_ERROR(_zh, ...) LOG_ERROR(LOGCALLBACK(_zh), __VA_ARGS__)
 #define PHP_ZK_LOG_WARN(_zh, ...) LOG_WARN(LOGCALLBACK(_zh), __VA_ARGS__)
 #define PHP_ZK_LOG_INFO(_zh, ...) LOG_INFO(LOGCALLBACK(_zh), __VA_ARGS__)

--- a/php_zookeeper_log.c
+++ b/php_zookeeper_log.c
@@ -19,7 +19,7 @@
 #include <zookeeper_log.h> /* Symbol LOG_INFO defined in this file conflicts with the symbol defined in syslog.h */
 #include "php_zookeeper_log.h"
 
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
 #define PHP_ZK_LOG_ERROR(_zh, ...) LOG_ERROR(LOGCALLBACK(_zh), __VA_ARGS__)
 #define PHP_ZK_LOG_WARN(_zh, ...) LOG_WARN(LOGCALLBACK(_zh), __VA_ARGS__)
 #define PHP_ZK_LOG_INFO(_zh, ...) LOG_INFO(LOGCALLBACK(_zh), __VA_ARGS__)

--- a/zoo_lock.c
+++ b/zoo_lock.c
@@ -97,7 +97,7 @@ ZOOAPI int zkr_lock_unlock(zkr_lock_mutex_t *mutex) {
         while (ret == ZCONNECTIONLOSS && (count < 3)) {
             ret = zoo_delete(zh, buf, -1);
             if (ret == ZCONNECTIONLOSS) {
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                 LOG_DEBUG(LOGCALLBACK(zh), ("connectionloss while deleting the node"));
 #else
                 LOG_DEBUG(("connectionloss while deleting the node"));
@@ -117,7 +117,7 @@ ZOOAPI int zkr_lock_unlock(zkr_lock_mutex_t *mutex) {
             pthread_mutex_unlock(&(mutex->pmutex));
             return 0;
         }
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
         LOG_WARN(LOGCALLBACK(zh), ("not able to connect to server - giving up"));
 #else
         LOG_WARN(("not able to connect to server - giving up"));
@@ -188,7 +188,7 @@ static int retry_getchildren(zhandle_t *zh, char* path, struct String_vector *ve
     while (ret == ZCONNECTIONLOSS && count < retry) {
         ret = zoo_get_children(zh, path, 0, vector);
         if (ret == ZCONNECTIONLOSS) {
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
             LOG_DEBUG(LOGCALLBACK(zh), ("connection loss to the server"));
 #else
             LOG_DEBUG(("connection loss to the server"));
@@ -228,7 +228,7 @@ static int retry_zoowexists(zhandle_t *zh, char* path, watcher_fn watcher, void*
     while (ret == ZCONNECTIONLOSS && count < retry) {
         ret = zoo_wexists(zh, path, watcher, ctx, stat);
         if (ret == ZCONNECTIONLOSS) {
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
             LOG_DEBUG(LOGCALLBACK(zh), ("connectionloss while setting watch on my predecessor"));
 #else
             LOG_DEBUG(("connectionloss while setting watch on my predecessor"));
@@ -287,7 +287,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
             // do not want to retry the create since
             // we would end up creating more than one child
             if (ret != ZOK) {
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                 LOG_WARN(LOGCALLBACK(zh), ("could not create zoo node %s", buf));
 #else
                 LOG_WARN(("could not create zoo node %s", buf));
@@ -301,7 +301,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
             ret = ZCONNECTIONLOSS;
             ret = retry_getchildren(zh, path, vector, ts, retry);
             if (ret != ZOK) {
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                 LOG_WARN(LOGCALLBACK(zh), ("could not connect to server"));
 #else
                 LOG_WARN(("could not connect to server"));
@@ -327,7 +327,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
                 // will keep waiting
                 if (ret != ZOK) {
                     free_String_vector(vector);
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                     LOG_WARN(LOGCALLBACK(zh), ("unable to watch my predecessor"));
 #else
                     LOG_WARN(("unable to watch my predecessor"));
@@ -347,7 +347,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
                 // this is the case when we are the owner
                 // of the lock
                 if (strcmp(mutex->id, owner_id) == 0) {
-#if ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5
+#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                     LOG_DEBUG(LOGCALLBACK(zh), ("got the zoo lock owner - %s", mutex->id));
 #else
                     LOG_DEBUG(("got the zoo lock owner - %s", mutex->id));

--- a/zoo_lock.c
+++ b/zoo_lock.c
@@ -97,7 +97,7 @@ ZOOAPI int zkr_lock_unlock(zkr_lock_mutex_t *mutex) {
         while (ret == ZCONNECTIONLOSS && (count < 3)) {
             ret = zoo_delete(zh, buf, -1);
             if (ret == ZCONNECTIONLOSS) {
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                 LOG_DEBUG(LOGCALLBACK(zh), ("connectionloss while deleting the node"));
 #else
                 LOG_DEBUG(("connectionloss while deleting the node"));
@@ -117,7 +117,7 @@ ZOOAPI int zkr_lock_unlock(zkr_lock_mutex_t *mutex) {
             pthread_mutex_unlock(&(mutex->pmutex));
             return 0;
         }
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
         LOG_WARN(LOGCALLBACK(zh), ("not able to connect to server - giving up"));
 #else
         LOG_WARN(("not able to connect to server - giving up"));
@@ -188,7 +188,7 @@ static int retry_getchildren(zhandle_t *zh, char* path, struct String_vector *ve
     while (ret == ZCONNECTIONLOSS && count < retry) {
         ret = zoo_get_children(zh, path, 0, vector);
         if (ret == ZCONNECTIONLOSS) {
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
             LOG_DEBUG(LOGCALLBACK(zh), ("connection loss to the server"));
 #else
             LOG_DEBUG(("connection loss to the server"));
@@ -228,7 +228,7 @@ static int retry_zoowexists(zhandle_t *zh, char* path, watcher_fn watcher, void*
     while (ret == ZCONNECTIONLOSS && count < retry) {
         ret = zoo_wexists(zh, path, watcher, ctx, stat);
         if (ret == ZCONNECTIONLOSS) {
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
             LOG_DEBUG(LOGCALLBACK(zh), ("connectionloss while setting watch on my predecessor"));
 #else
             LOG_DEBUG(("connectionloss while setting watch on my predecessor"));
@@ -287,7 +287,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
             // do not want to retry the create since
             // we would end up creating more than one child
             if (ret != ZOK) {
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                 LOG_WARN(LOGCALLBACK(zh), ("could not create zoo node %s", buf));
 #else
                 LOG_WARN(("could not create zoo node %s", buf));
@@ -301,7 +301,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
             ret = ZCONNECTIONLOSS;
             ret = retry_getchildren(zh, path, vector, ts, retry);
             if (ret != ZOK) {
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                 LOG_WARN(LOGCALLBACK(zh), ("could not connect to server"));
 #else
                 LOG_WARN(("could not connect to server"));
@@ -327,7 +327,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
                 // will keep waiting
                 if (ret != ZOK) {
                     free_String_vector(vector);
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                     LOG_WARN(LOGCALLBACK(zh), ("unable to watch my predecessor"));
 #else
                     LOG_WARN(("unable to watch my predecessor"));
@@ -347,7 +347,7 @@ static int zkr_lock_operation(zkr_lock_mutex_t *mutex, struct timespec *ts) {
                 // this is the case when we are the owner
                 // of the lock
                 if (strcmp(mutex->id, owner_id) == 0) {
-#if defined(ZOO_VERSION) || (defined(ZOO_MAJOR_VERSION) && ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
+#if defined(ZOO_VERSION) || (ZOO_MAJOR_VERSION>=3 && ZOO_MINOR_VERSION>=5)
                     LOG_DEBUG(LOGCALLBACK(zh), ("got the zoo lock owner - %s", mutex->id));
 #else
                     LOG_DEBUG(("got the zoo lock owner - %s", mutex->id));


### PR DESCRIPTION
Instead of the separate version definitions, there's now a single ZOO_VERSION definition.

Related to #42 