### PR TITLE
Fix PHP 8.0 tests under ZTS

### DIFF
--- a/.travis/install_libzookeeper.sh
+++ b/.travis/install_libzookeeper.sh
@@ -5,13 +5,12 @@ LIBZOOKEEPER_MAJOR_VERSION=`echo ${LIBZOOKEEPER_VERSION} | awk -F'.' '{print $1}
 LIBZOOKEEPER_MINOR_VERSION=`echo ${LIBZOOKEEPER_VERSION} | awk -F'.' '{print $2}'`
 LIBZOOKEEPER_PATCH_VERSION=`echo ${LIBZOOKEEPER_VERSION} | awk -F'.' '{print $3}'`
 
-if [ ${LIBZOOKEEPER_MAJOR_VERSION} -ge 3 -a ${LIBZOOKEEPER_MINOR_VERSION} -ge 5 -a ${LIBZOOKEEPER_PATCH_VERSION} -ge 9 ]; then
+if [ ${LIBZOOKEEPER_MAJOR_VERSION} -ge 3 -a ${LIBZOOKEEPER_MINOR_VERSION} -ge 5 ]; then
     PACKAGE_NAME=apache-zookeeper-${LIBZOOKEEPER_VERSION}
-    URL_PREFIX=http://apache.mirrors.lucidnetworks.net/zookeeper
 else
     PACKAGE_NAME=zookeeper-${LIBZOOKEEPER_VERSION}
-    URL_PREFIX=http://archive.apache.org/dist/zookeeper
 fi
+URL_PREFIX=http://archive.apache.org/dist/zookeeper
 URL_DIR_NAME=zookeeper-${LIBZOOKEEPER_VERSION}
 LIBZOOKEEPER_PREFIX=${HOME}/lib${URL_DIR_NAME}
 

--- a/php_zookeeper.c
+++ b/php_zookeeper.c
@@ -52,6 +52,16 @@
 #include "php_zookeeper_log.h"
 
 /****************************************
+  PHP 8.0 compat
+****************************************/
+#if PHP_VERSION_ID >= 80000
+void *tsrm_set_interpreter_context(void *ctx)
+{
+	return NULL;
+}
+#endif
+
+/****************************************
   Helper macros
 ****************************************/
 

--- a/php_zookeeper.h
+++ b/php_zookeeper.h
@@ -42,7 +42,10 @@ extern zend_module_entry zookeeper_module_entry;
 #define TSRMLS_CC
 #define TSRMLS_FETCH()
 #define TSRMLS_FETCH_FROM_CTX(z)
-#define tsrm_set_interpreter_context(z)
+void *tsrm_set_interpreter_context(void *new_ctx)
+{
+	return NULL;
+}
 #endif // if PHP >= 8.0
 #endif
 

--- a/php_zookeeper.h
+++ b/php_zookeeper.h
@@ -42,10 +42,6 @@ extern zend_module_entry zookeeper_module_entry;
 #define TSRMLS_CC
 #define TSRMLS_FETCH()
 #define TSRMLS_FETCH_FROM_CTX(z)
-void *tsrm_set_interpreter_context(void *new_ctx)
-{
-	return NULL;
-}
 #endif // if PHP >= 8.0
 #endif
 


### PR DESCRIPTION
It looks like the version of PHP on Travis was compiled with ZTS mode turned on and the tests are failing because the macro for the now undefined `tsrm_set_interpreter_context` function was replacing everything but the semicolon, and the semicolon was causing compilation errors.

So in this fix, instead of a macro I just used a function that returns a null pointer, so it should compile correctly now. I suppose we'll see if that's true once the travis tests run 😅