### PR TITLE
Support PHP 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 7.2
     - 7.1
     - 7.0
+    - nightly
 
 env:
     - LIBZOOKEEPER_VERSION=3.7.1
@@ -20,6 +21,8 @@ jobs:
           php: 8.1.0
         - dist: bionic
           php: 8.2.0
+    allow_failures:
+        - php: nightly
 
 addons:
   apt:

--- a/package.xml
+++ b/package.xml
@@ -77,7 +77,7 @@ Bugs:
   <required>
    <php>
     <min>7.0.0</min>
-    <max>8.2.99</max>
+    <max>8.3.99</max>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
Closes #60 

I'm not sure if travis is still running the tests, but I added nightly PHP to the build matrix. For now, Travis doesn't have 8.3 builds available, but the nightly should suffice. I also marked nightly as being allowed to fail, since it's more of a canary to indicate what needs updating before it gets released.